### PR TITLE
Correct simulator's transcript equation

### DIFF
--- a/testzkp.tex
+++ b/testzkp.tex
@@ -641,7 +641,7 @@ Simulator can fake the transcript by choosing out of order (it's only a
 slightly more algebraically involved issue here: you choose $(\textbf{z},
 s)$ both at random, as well as $e$, and you can deduce the right value of
 the point:
-\[C_0 \ = \ \left(sH + \mathbf{z}\mathbf{G}\right)-\left(\sum\limits_{i=1}^{m}e^{-i}C_{i}\right)\]
+\[C_0 \ = \ \left(sH + \mathbf{z}\mathbf{G}\right)-\left(\sum\limits_{i=1}^{m}e^{i}C_{i}\right)\]
 (remember, the $C_1, C_2, \ldots ,C_m$ are all set in advance). It's easy to see that this will
 mean that the entire transcript will look valid to a third party, and
 it's less obvious but certainly plausible that the statistical


### PR DESCRIPTION
In section 3.2, the simulator's transcript equation in the zero
knowledgeness proof had an unnecessary negative exponent. Remove it.