### PR TITLE
Clarify section 4.2

### DIFF
--- a/testzkp.tex
+++ b/testzkp.tex
@@ -1048,9 +1048,9 @@ proof]{\texorpdfstring{\protect\hypertarget{anchor-36}{}{}The commitment
 step for the inner product
 proof}{The commitment step for the inner product proof}}\label{the-commitment-step-for-the-inner-product-proof}}
 
-The Prover P will need to send \emph{two }commitments, analogous to the
+The Prover P will need to send commitments to \emph{two } nonce vectors, analogous to the
 $R$ value in the above description -- one for each of $\mathbf{x}$ and
-$\mathbf{y}$. These will be called $\mathbf{d}_x, \mathbf{d}_y$ respectively. But there's another
+$\mathbf{y}$. These nonce vectors will be called $\mathbf{d}_x, \mathbf{d}_y$ respectively. But there's another
 difference -- in our stated problem, we have Pedersen commitments to the
 vectors, rather than the vectors themselves (this is analogous to how,
 in the Schnorr protocol, you have a public key $P$, not the secret $x$, so you

--- a/testzkp.tex
+++ b/testzkp.tex
@@ -1069,7 +1069,7 @@ so here our final response(s) are of the form $e\mathbf{x}+\mathbf{d}$, more spe
 
 However, that's not enough; we're trying to prove an inner product, too.
 
-What we'll have to do also in the challenge step is to send a
+What we'll have to do also in the commitment step is to send a
 \emph{commitment} to the expected inner product of this \emph{blinded}
 form of our vectors. The blinded form has already been mentioned as $e\mathbf{x} + \mathbf{d}_x, e\mathbf{y}+\mathbf{d}_y$,
 but we don't yet know the challenge $e$, so we have to factor that out


### PR DESCRIPTION
A couple of places that tripped me up in section 4.2:

- existing wording made it sound like dx and dy were commitments rather than nonce vectors, which the prover then sends commitments to. I've added some suggested wording changes to make this clearer.
- currently, section 4.2 says that a commitment to the dot product is sent in the challenge step. I believe this should say the commitment step.